### PR TITLE
Fix view projection

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -77,11 +77,9 @@ fn camera_system(
 
 fn light_direction(time: Res<Time>, mut query: Query<&mut DirectionalLight>) {
     for mut light in query.iter_mut() {
-        light.set_direction(Vec3::new(
-            time.seconds_since_startup().sin() as f32,
-            -1.0,
-            0.0,
-        ));
+        let theta = std::f32::consts::TAU * time.seconds_since_startup() as f32 / 10.0;
+        let (s, c) = theta.sin_cos();
+        light.set_direction(Vec3::new(c, -1.0, s));
     }
 }
 

--- a/src/directional_light.rs
+++ b/src/directional_light.rs
@@ -41,4 +41,9 @@ impl Light for DirectionalLight {
         }
         .get_projection_matrix()
     }
+
+    fn view_matrix(&self) -> Mat4 {
+        let eye_position = -40.0 * self.get_direction();
+        Mat4::look_at_rh(eye_position, Vec3::ZERO, Vec3::Y)
+    }
 }

--- a/src/directional_light.rs
+++ b/src/directional_light.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy::render::camera::{CameraProjection, OrthographicProjection};
 
 pub struct ShadowDirectionalLight {
-    /// Size of the area covered by the light. 
+    /// Size of the area covered by the light.
     /// Everything outside will be lit by default.
     pub size: f32,
     /// Near plane of projection.

--- a/src/directional_light.rs
+++ b/src/directional_light.rs
@@ -26,9 +26,6 @@ impl Light for DirectionalLight {
     type Config = ShadowDirectionalLight;
 
     fn proj_matrix(&self, config: Option<&Self::Config>) -> Mat4 {
-        let dir = self.get_direction().normalize();
-        let rot = Quat::from_rotation_arc(Vec3::Z, dir);
-
         let d = config.map_or(25.0, |config| config.size / 2.0);
         let near = config.map_or(-500.0, |config| config.near);
         let far = config.map_or(500.0, |config| config.far);
@@ -43,6 +40,5 @@ impl Light for DirectionalLight {
             ..Default::default()
         }
         .get_projection_matrix()
-            * Mat4::from_quat(rot)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ use bevy::prelude::*;
 use shadow_pass_node::ShadowLights;
 
 pub mod prelude {
+    pub use crate::directional_light::ShadowDirectionalLight;
     pub use crate::render_graph::{DIRECTIONAL_LIGHT_DEPTH_HANDLE, SHADOW_PBR_PIPELINE};
     pub use crate::shadow_pass_node::Shadowless;
     pub use crate::ShadowPlugin;
-    pub use crate::directional_light::ShadowDirectionalLight;
 }
 
 pub struct ShadowPlugin {

--- a/src/shadow_pass_node.rs
+++ b/src/shadow_pass_node.rs
@@ -51,6 +51,7 @@ pub trait Light: Send + Sync + 'static {
     type Config: Send + Sync + 'static;
 
     fn proj_matrix(&self, config: Option<&Self::Config>) -> Mat4;
+    fn view_matrix(&self) -> Mat4;
 }
 
 #[derive(Default)]

--- a/src/shadow_pass_node.rs
+++ b/src/shadow_pass_node.rs
@@ -253,12 +253,8 @@ impl<L: Light> Node for LightsNode<L> {
                             query_state.get(world, *entity)
                         {
                             let proj = light.proj_matrix(config);
-                            let view = Mat4::from_scale_rotation_translation(
-                                global_transform.scale,
-                                Quat::IDENTITY,
-                                global_transform.translation,
-                            );
-                            let view_proj = proj * view.inverse();
+                            let view = light.view_matrix();
+                            let view_proj = proj * view;
 
                             shadow_light.pos = global_transform.translation;
                             shadow_light.view_proj = view_proj;


### PR DESCRIPTION
The projection matrix should not itself include the rotation. The view matrix it seems must be not only oriented along the direction of the light, but must be a Mat4::look_at_rh() from somewhere backwards along the light direction looking at the origin. With this, the shadows are correctly placed.

Handling the box defined by the orthographic projection that encloses the shadows will be handled in a separate PR.